### PR TITLE
Skip intersections when max is less than origin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1264,7 +1264,7 @@ mod tests {
     }
 
     #[test]
-    fn regression3() {
+    fn skips_intersections_if_max_bound_less_than_origin() {
         let mut t = SieveTree::<1, 2, Bounds<1>>::with_granularity(1.);
         let b1 = Bounds {
             min: [10.],

--- a/src/traversal.rs
+++ b/src/traversal.rs
@@ -36,10 +36,15 @@ pub struct Intersections<'a, const DIM: usize, const GRID_EXPONENT: u32, T> {
 
 impl<'a, const DIM: usize, const GRID_EXPONENT: u32, T> Intersections<'a, DIM, GRID_EXPONENT, T> {
     pub(crate) fn new(
-        bounds: TreeBounds<DIM>,
+        maybe_bounds: Option<TreeBounds<DIM>>,
         elements: &'a Slab<Element<T>>,
         root: Option<&'a Root<DIM, GRID_EXPONENT>>,
     ) -> Self {
+        let bounds = maybe_bounds.unwrap_or(TreeBounds {
+            min: [0; DIM],
+            max: [0; DIM],
+        });
+
         let mut out = Intersections {
             bounds,
             elements,
@@ -50,6 +55,12 @@ impl<'a, const DIM: usize, const GRID_EXPONENT: u32, T> Intersections<'a, DIM, G
             next_element: ElementIter::default(),
             grid: &[],
         };
+
+        // Skip traversal if the provided bounds are empty
+        if maybe_bounds.is_none() {
+            return out;
+        }
+
         if let Some(root) = root {
             if bounds.intersects(&root.coords.bounds()) {
                 out.traversal.push(root.coords, &root.node);


### PR DESCRIPTION
Fixes #20

- Added a `_checked` variant of `tree_from_world` that will return `None` if the location is before the origin (i.e., can't be represented as a tree location without saturating to 0).
- Use the `_checked` variant to test if the intersection max is less than the origin component-wise, if so early out from the intersection traversal.